### PR TITLE
Create alumni page

### DIFF
--- a/source/_data/people.yml
+++ b/source/_data/people.yml
@@ -14,7 +14,8 @@
 - pid: schmidt
   done: true
   name: Benjamin Schmidt
-  titles: Director of Digital Humanities and Clinical Associate Professor of History
+  titles: Former Director of Digital Humanities and Clinical Associate Professor of
+    History
   site_roles:
   - alum
   link: https://benschmidt.org
@@ -103,7 +104,8 @@
 - pid: gan
   done: true
   name: Elaine Gan
-  titles: Visiting Assistant Professor in Experimental Humanities & Social Engagement
+  titles: Former Visiting Assistant Professor in Experimental Humanities & Social
+    Engagement
   site_roles:
   - alum
   link: https://as.nyu.edu/content/nyu-as/as/faculty/elaine-gan.html
@@ -158,7 +160,8 @@
 - pid: keramidas
   done: true
   name: Kimon Keramidas
-  titles: Clinical Associate Professor in Experimental Humanities & Social Engagement
+  titles: Former Clinical Associate Professor in Experimental Humanities & Social
+    Engagement
   site_roles:
   - alum
   link: https://as.nyu.edu/faculty/kimon-keramidas.html

--- a/source/people.md
+++ b/source/people.md
@@ -8,10 +8,10 @@ contents_links:
       link: 'executive-committee'
     - label: 'Project PIs'
       link: 'project-pis'
-    - label: 'Affiliated Teaching Faculty'
-      link: 'affiliated-faculty'
     - label: 'Graduate Student Fellows'
       link: 'graduate-student-fellows'
+    - label: 'Alumni'
+      link: 'alumni'
 ---
 
 {% assign people = site.data.people | where: 'affiliated', true | sort: 'order' %}

--- a/source/people/alumni.md
+++ b/source/people/alumni.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: NYU DH Alumni
+breadcrumbs:
+  - name: People
+    link: /people
+---
+{% assign people = site.data.people | where_exp: "p", "p.site_roles contains 'alum'" %}
+{% assign people = people | sort: 'order' %}
+{% include cards/people.html data=people full_width=false %}


### PR DESCRIPTION
Created new page for Alumni. On the People page, added Alumni to the quick links section and dropped Affiliated Teaching Faculty because > 4 quick links is too much (it's still in quick links on the Courses pages). Bon voyage, comrades!