### PR TITLE
Add example Seed Grant CFP

### DIFF
--- a/source/_news/2021-09-28-showcase2021.md
+++ b/source/_news/2021-09-28-showcase2021.md
@@ -37,5 +37,6 @@ The Center for the Humanities is committed to making our events as accessible as
 This event is co-sponsored by NYU Libraries and NYU Research Technology.
 
 Direct Registration Link: <https://www.eventbrite.com/e/2021-digital-humanities-showcase-tickets-180400782597>
+{: .data-proofer-ignore }
 
 Center for the Humanities Website: <https://nyuhumanities.org/event/2021-digital-humanities-showcase/>

--- a/source/funding/seed-grants/sample-call.md
+++ b/source/funding/seed-grants/sample-call.md
@@ -1,0 +1,89 @@
+---
+layout: page
+title: Sample Call for Applications
+breadcrumbs:
+  - name: Seed Grants
+    link: /funding/seed-grants/
+  - name: FAQ
+    link: /funding/seed-grants/faq/
+---
+*Copied below is the call for proposals for the 2022 Seed Grants.*
+
+<hr>
+
+**Deadline:** March 6, 2022 (11:59 pm EST)
+
+**Call for Applications**
+
+The Center for the Humanities, in partnership with the NYU Libraries and NYU Research Technology invites applications for a third series of Digital Humanities Seed Grants. These grants are intended to fund the initial development of new research projects that will analyze digital sources, apply algorithmic methods to humanities data, or create digital publications, exhibits, or websites. The goal of the program is to seed projects that may go on to receive greater funding from other sources or otherwise build NYU’s institutional capacity in Digital Humanities work.
+
+We especially welcome projects that give voice or expression to underrepresented communities; that engage with the urban fabric of the cities in which NYU has campuses; and that contribute to the emerging subfield of Global Digital Humanities.
+
+Grants may range in size between $5,000 and $20,000. Collaborative projects are encouraged, but must include at least one NYU faculty member in the humanities.
+
+**Eligibility**
+
+Proposals must include at least one full-time NYU faculty member working in the humanities; collaborative projects are highly welcome. There are no restrictions on school, department, or rank, but proposals from faculty in interdisciplinary departments may wish to identify how their research identifies with the humanities. Graduate students seeking funding should apply under the DH summer fellowship program.
+
+Equal Opportunity Statement: NYU-funded programs do not discriminate on the basis of race, color, national origin, sex, disability, or age. For more information, please visit <https://www.nyu.edu/about/policies-guidelines-compliance/equal-opportunity.html>.
+
+**Review Process**
+
+Applications will be reviewed by a faculty committee with experience in Digital Humanities projects. Projects will be judged on scholarly potential, technical feasibility, sustainability of any scholarly outputs produced, and their potential to serve as the foundation of some longer-term research project. The review committee will meet in Spring 2022 and awards will be announced in April 2022.
+
+The application period for this grant closes on March 6, 2022; we anticipate a fourth series will be solicited next year.
+
+**Schedule**
+
+March 6, 2022, 11:59 pm, EST:   Deadline  
+March 2022:                     Review panel meets for evaluation period  
+April 2022:                     Decisions announced  
+May 1, 2022:                    Funds available  
+August 31, 2022:                Funds must be transferred to receiving department  
+August 31, 2023:                Project end date, funds must be spent down  
+September 2023:                 Project presentations  
+
+
+**Obligations**
+
+Prior to availability of funding, project members will consult with appropriate staff at NYU Libraries or Research Technology about their plans for creating and sustaining any digital resources.
+
+Grantees will give two short presentations to the NYU committee, either as part of a panel at the Center for the Humanities or in some other agreed-upon setting. The first will be a work-in-progress talk after the grant period is underway; the second is after its completion and will be accompanied by a short white paper outlining the project’s successes, failures, and future potential.
+
+Additionally, grantees who receive funding may be called upon to serve on the review panel the following year.
+
+**Funding Management**
+
+Grants may range in size between $5,000 and $20,000. Grantees will be provided with a budgeted chartfield and the grantee’s academic unit will be responsible for administering the funds. All expenditure must be in compliance with University, School or Department fiscal regulations, whichever is most stringent.
+
+**Deadline**
+
+Applications must be received by March 6, 2022, 11:59 pm, EST.
+
+**Application Instructions**
+
+_Proposals should not exceed three pages_, plus a single-page budget summary, and any necessary letters of commitment. Successful projects will generally address the following elements:
+
+- **Abstract** summarizing the project in 200 words; this may be used in funding announcements.
+
+- **Research agenda**, including an intellectual justification of the project and its significance to humanities research.
+
+- **Environmental scan** describing projects informing the one proposed here.
+
+- **Work plan** giving a timeline of the agenda to be pursued, including key dates and milestones.
+
+- **Human subjects plan** if the work would require [IRB](https://www.nyu.edu/research/resources-and-support-offices/getting-started-withyourresearch/human-subjects-research.html) (note that most humanities research will not).
+
+- **List of participants**, clearly spelling out their names, roles, and qualifications. In cases where a role is defined but no individual has yet been identified (e.g., ‘web developer’ or ‘undergraduate research assistant’, please provide a one-paragraph description of the person’s role.)
+
+- **Sustainability plan**, where relevant, explaining how digital assets created by this project will be managed and preserved. For a sense of full sustainability plans, see statements from NEH and IMLS. Applicants are encouraged to consult with Digital Scholarship Services about the feasibility of any plans. A preference will be given to projects that make any resources (scholarship, code, or data) openly available unless they give a justification here of the ways such openness would be detrimental to individuals or communities.
+
+- **Future agenda** describing the goals for this project beyond the granting period. This may include relevant granting programs for a larger version, a description of the impact or future use of resources created in the grant period. Projects will be given preference that hold promise to expand NYU’s institutional capacity to support and create high-quality Digital Humanities research. How do you plan to sustain the results of the project beyond the funding period?
+
+- **Single page budget**. Grants may range in size between $5,000 and $20,000. Permissible expenses include student stipends, course buy-outs, partial summer salary, and specific equipment, server time, or hosting. Personal computer purchases are not permitted. Final awards may be altered at the recommendation of the evaluation committee
+
+- **LETTERS OF COMMITMENT**: Faculty requesting a course release must include a letter from their department chair (or, for Gallatin applicants, dean) indicating the department’s willingness to free the grantee from teaching assignments. It should specify the proposed course release and resulting course assignment and describe how the department will address the impact, if any, on the department’s undergraduate program.
+
+**For More Information:**
+
+Please address any questions or requests for consultations are available to <dh.help@nyu.edu>.


### PR DESCRIPTION
Using the Grad Fellows' example CFP as the template. This page is not linked to on the site, but would be nice to have the an example CFP on the DH site.